### PR TITLE
Use python:3.8-buster as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY poa/keystore /opt/poa/keystore
 
 
 # MPC program compilation to bytecodes
-FROM python:3.8 as mpc-bytecodes
+FROM python:3.8-buster as mpc-bytecodes
 
 ENV PYTHONUNBUFFERED 1
 
@@ -36,7 +36,7 @@ RUN bash compile.sh
 
 
 # main image
-FROM python:3.8
+FROM python:3.8-buster
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8 as base-mp-spdz
+FROM python:3.8-buster as base-mp-spdz
 
 ENV PYTHONUNBUFFERED 1
 
@@ -82,7 +82,7 @@ RUN make malicious-shamir-party.x
 ########################## end of mp-spdz builds #######################################
 
 #FROM base-mp-spdz as hbswap
-FROM python:3.8 as hbswap
+FROM python:3.8-buster as hbswap
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/mpspdzbuilds.Dockerfile
+++ b/docker/mpspdzbuilds.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8 as compiler
+FROM python:3.8-buster as compiler
 
 ENV PYTHONUNBUFFERED 1
 
@@ -9,7 +9,7 @@ COPY MP-SPDZ/Compiler Compiler
 RUN mkdir -p Programs/Source
 ###############################################################################
 
-FROM python:3.8 as machines
+FROM python:3.8-buster as machines
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
This ensures that the libboost version is 1.67.